### PR TITLE
Backport bugfixes from Lua 5.3

### DIFF
--- a/src/lgc.c
+++ b/src/lgc.c
@@ -629,8 +629,9 @@ static void clearkeys (global_State *g, GCObject *l, GCObject *f) {
     for (n = gnode(h, 0); n < limit; n++) {
       if (!ttisnil(gval(n)) && (iscleared(g, gkey(n)))) {
         setnilvalue(gval(n));  /* remove value ... */
-        removeentry(n);  /* and remove entry from table */
       }
+      if (ttisnil(gval(n)))  /* is entry empty? */
+        removeentry(n);  /* remove entry from table */
     }
   }
 }


### PR DESCRIPTION
This PR fixes the following bugs in Lua 5.2:

Wrong code generated for a 'goto' followed by a label inside an 'if'.
Dead keys with nil values can stay in weak tables.
Expression list with four or more expressions in a 'for' loop can crash the interpreter.
Label between local definitions can mix-up their initializations.

All examples have been tested to verify the fix and the Lua test suite still passes 100%